### PR TITLE
Add support for the custom CH32V003 port expander on Waveshare S3 Tou…

### DIFF
--- a/src/chip/esp_expander_waveshare_lcd_4_ch32v003.cpp
+++ b/src/chip/esp_expander_waveshare_lcd_4_ch32v003.cpp
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "esp_expander_utils.h"
+#include "port/esp_io_expander_waveshare_lcd_4_ch32v003.h"
+#include "esp_expander_waveshare_lcd_4_ch32v003.hpp"
+
+namespace esp_expander {
+
+WAVESHARE_LCD_4_CH32V003::~WAVESHARE_LCD_4_CH32V003()
+{
+    ESP_UTILS_LOG_TRACE_ENTER_WITH_THIS();
+
+    ESP_UTILS_CHECK_FALSE_EXIT(del(), "Delete failed");
+
+    ESP_UTILS_LOG_TRACE_EXIT_WITH_THIS();
+}
+
+bool WAVESHARE_LCD_4_CH32V003::begin(void)
+{
+    ESP_UTILS_LOG_TRACE_ENTER_WITH_THIS();
+
+    ESP_UTILS_CHECK_FALSE_RETURN(!isOverState(State::BEGIN), false, "Already begun");
+
+    // Initialize the device if not initialized
+    if (!isOverState(State::INIT)) {
+        ESP_UTILS_CHECK_FALSE_RETURN(init(), false, "Init failed");
+    }
+
+    ESP_UTILS_CHECK_ERROR_RETURN(
+        esp_io_expander_new_i2c_waveshare_lcd_4_ch32v003(
+            static_cast<i2c_port_t>(getConfig().host_id), getConfig().device.address, &device_handle
+        ), false, "Create WAVESHARE_LCD_4_CH32V003 failed"
+    );
+    ESP_UTILS_LOGD("Create WAVESHARE_LCD_4_CH32V003 @%p", device_handle);
+
+    setState(State::BEGIN);
+
+    ESP_UTILS_LOG_TRACE_EXIT_WITH_THIS();
+
+    return true;
+}
+
+bool WAVESHARE_LCD_4_CH32V003::setBacklight(uint8_t percent)
+{
+    ESP_UTILS_LOG_TRACE_ENTER_WITH_THIS();
+
+    ESP_UTILS_CHECK_FALSE_RETURN(isOverState(State::BEGIN), false, "Not begun");
+
+    if (percent > 100) {
+        percent = 100;
+    }
+    // PWM register is inverted: 0 = max brightness, 247 = off
+    uint8_t duty = (percent == 0) ? 247 : (uint8_t)(247 - ((uint32_t)percent * 247 / 100));
+
+    ESP_UTILS_CHECK_ERROR_RETURN(
+        esp_io_expander_waveshare_lcd_4_ch32v003_set_pwm(device_handle, duty), false, "Set backlight failed"
+    );
+
+    ESP_UTILS_LOG_TRACE_EXIT_WITH_THIS();
+
+    return true;
+}
+
+bool WAVESHARE_LCD_4_CH32V003::beep(bool on)
+{
+    ESP_UTILS_LOG_TRACE_ENTER_WITH_THIS();
+
+    ESP_UTILS_CHECK_FALSE_RETURN(isOverState(State::BEGIN), false, "Not begun");
+
+    ESP_UTILS_CHECK_FALSE_RETURN(digitalWrite(PIN_BEE_EN, on ? HIGH : LOW), false, "Set beep failed");
+
+    ESP_UTILS_LOG_TRACE_EXIT_WITH_THIS();
+
+    return true;
+}
+
+} // namespace esp_expander

--- a/src/chip/esp_expander_waveshare_lcd_4_ch32v003.hpp
+++ b/src/chip/esp_expander_waveshare_lcd_4_ch32v003.hpp
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "esp_expander_base.hpp"
+
+namespace esp_expander {
+
+/**
+ * @brief The Waveshare ESP32-S3-Touch-LCD-4 CH32V003 IO expander device class
+ *
+ * @note  This class is a derived class of `esp_expander::Base`, user can use it directly.
+ * @note  The CH32V003 is a microcontroller acting as an I2C IO expander. The pin map below is
+ *        specific to the firmware shipped on the Waveshare ESP32-S3-Touch-LCD-4 (4" square) board.
+ * @note  Pin map (register bit -> function):
+ *        | Pin Number | 1      | 2      | 3       | 4    | 5      | 6      | 7       |
+ *        | ---------- | ------ | ------ | ------- | ---- | ------ | ------ | ------- |
+ *        | Function   | TP_RST | TP_INT | LCD_RST | SDCD | SYS_EN | BEE_EN | RTC_INT |
+ */
+class WAVESHARE_LCD_4_CH32V003: public Base {
+public:
+    /**
+     * @brief Pin (register bit) assignment for the LCD4 board firmware
+     */
+    enum Pin {
+        PIN_TP_RST  = 1,    // EXIO1: touch panel reset
+        PIN_TP_INT  = 2,    // EXIO2: touch panel interrupt / GT911 address strap
+        PIN_LCD_RST = 3,    // EXIO3: LCD reset
+        PIN_SD_CD   = 4,    // EXIO4: SD card detect
+        PIN_SYS_EN  = 5,    // EXIO5: system / peripheral power enable
+        PIN_BEE_EN  = 6,    // EXIO6: beeper enable
+        PIN_RTC_INT = 7,    // EXIO7: RTC interrupt
+    };
+
+    /**
+     * @brief Construct a device. With this function, call `init()` will initialize I2C by using the host
+     *        configuration.
+     *
+     * @param[in] scl_io  I2C SCL pin number
+     * @param[in] sda_io  I2C SDA pin number
+     * @param[in] address I2C device 7-bit address. Should be `ESP_IO_EXPANDER_I2C_WAVESHARE_LCD_4_CH32V003_ADDRESS`.
+     */
+    WAVESHARE_LCD_4_CH32V003(int scl_io, int sda_io, uint8_t address): Base(scl_io, sda_io, address) {}
+
+    /**
+     * @brief Construct a device. With this function, call `init()` will not initialize I2C, and users should
+     *        initialize it manually.
+     *
+     * @param[in] host_id I2C host ID.
+     * @param[in] address I2C device 7-bit address. Should be `ESP_IO_EXPANDER_I2C_WAVESHARE_LCD_4_CH32V003_ADDRESS`.
+     */
+    WAVESHARE_LCD_4_CH32V003(int host_id, uint8_t address): Base(host_id, address) {}
+
+    /**
+     * @brief Construct a device.
+     *
+     * @param[in] config Configuration for the object
+     */
+    WAVESHARE_LCD_4_CH32V003(const Config &config): Base(config) {}
+
+    /**
+     * @brief Destruct object. This function will call `del()` to delete the object.
+     */
+    ~WAVESHARE_LCD_4_CH32V003() override;
+
+    /**
+     * @brief Begin object
+     *
+     * @note  This function typically calls `esp_io_expander_new_i2c_*()` to create the IO expander handle.
+     *
+     * @return true if success, otherwise false
+     */
+    bool begin(void) override;
+
+    /**
+     * @brief Set the backlight brightness
+     *
+     * @note  Backlight is driven by the CH32V003's dedicated PWM register, which is not part of the
+     *        generic GPIO model.
+     *
+     * @param[in] percent Brightness percentage, 0 (off) to 100 (max)
+     *
+     * @return true if success, otherwise false
+     */
+    bool setBacklight(uint8_t percent);
+
+    /**
+     * @brief Turn the beeper on or off
+     *
+     * @note  The beeper is on EXIO6 (BEE_EN). The pin should be configured as output before use.
+     *
+     * @param[in] on true to enable the beeper, false to disable
+     *
+     * @return true if success, otherwise false
+     */
+    bool beep(bool on);
+};
+
+} // namespace esp_expander

--- a/src/esp_io_expander.hpp
+++ b/src/esp_io_expander.hpp
@@ -12,6 +12,7 @@
 #include "port/esp_io_expander_ht8574.h"
 #include "port/esp_io_expander_tca9554.h"
 #include "port/esp_io_expander_tca95xx_16bit.h"
+#include "port/esp_io_expander_waveshare_lcd_4_ch32v003.h"
 
 /* Wrapper classes */
 #include "chip/esp_expander_base.hpp"
@@ -19,3 +20,4 @@
 #include "chip/esp_expander_ht8574.hpp"
 #include "chip/esp_expander_tca95xx_8bit.hpp"
 #include "chip/esp_expander_tca95xx_16bit.hpp"
+#include "chip/esp_expander_waveshare_lcd_4_ch32v003.hpp"

--- a/src/port/esp_io_expander_waveshare_lcd_4_ch32v003.c
+++ b/src/port/esp_io_expander_waveshare_lcd_4_ch32v003.c
@@ -1,0 +1,177 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <inttypes.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "driver/i2c.h"
+#include "esp_bit_defs.h"
+#include "esp_check.h"
+#include "esp_log.h"
+
+#include "esp_io_expander.h"
+#include "esp_io_expander_waveshare_lcd_4_ch32v003.h"
+
+#include "esp_expander_utils.h"
+
+/* Timeout of each I2C communication.
+ * The CH32V003 briefly stretches/holds the bus when its beeper bit is toggled, so a short timeout
+ * makes the transaction fail and drives the (legacy) I2C driver into i2c_hw_fsm_reset(), which can
+ * trip the interrupt watchdog. 100 ms matches the Arduino `Wire` default that previously tolerated it. */
+#define I2C_TIMEOUT_MS          (100)
+
+#define IO_COUNT                (8)
+
+/* Register address */
+#define INPUT_REG_ADDR          (0x00)
+#define OUTPUT_REG_ADDR         (0x02)
+#define DIRECTION_REG_ADDR      (0x03)
+#define PWM_REG_ADDR            (0x05)
+
+/* Default register value (all pins input, output latch low) */
+#define DIR_REG_DEFAULT_VAL     (0x00)   // 0 = input on this firmware
+#define OUT_REG_DEFAULT_VAL     (0x00)
+
+/**
+ * @brief Device Structure Type
+ */
+typedef struct {
+    esp_io_expander_t base;
+    i2c_port_t i2c_num;
+    uint32_t i2c_address;
+    struct {
+        uint8_t direction;
+        uint8_t output;
+    } regs;
+} esp_io_expander_ch32v003_t;
+
+static const char *TAG = "ch32v003_lcd4";
+
+static esp_err_t read_input_reg(esp_io_expander_handle_t handle, uint32_t *value);
+static esp_err_t write_output_reg(esp_io_expander_handle_t handle, uint32_t value);
+static esp_err_t read_output_reg(esp_io_expander_handle_t handle, uint32_t *value);
+static esp_err_t write_direction_reg(esp_io_expander_handle_t handle, uint32_t value);
+static esp_err_t read_direction_reg(esp_io_expander_handle_t handle, uint32_t *value);
+static esp_err_t reset(esp_io_expander_t *handle);
+static esp_err_t del(esp_io_expander_t *handle);
+
+esp_err_t esp_io_expander_new_i2c_waveshare_lcd_4_ch32v003(i2c_port_t i2c_num, uint32_t i2c_address,
+        esp_io_expander_handle_t *handle)
+{
+    ESP_LOGI(TAG, "version: %d.%d.%d", ESP_IO_EXPANDER_WAVESHARE_LCD_4_CH32V003_VER_MAJOR,
+             ESP_IO_EXPANDER_WAVESHARE_LCD_4_CH32V003_VER_MINOR, ESP_IO_EXPANDER_WAVESHARE_LCD_4_CH32V003_VER_PATCH);
+    ESP_RETURN_ON_FALSE(i2c_num < I2C_NUM_MAX, ESP_ERR_INVALID_ARG, TAG, "Invalid i2c num");
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "Invalid handle");
+
+    esp_io_expander_ch32v003_t *ch32v003 = (esp_io_expander_ch32v003_t *)calloc(1, sizeof(esp_io_expander_ch32v003_t));
+    ESP_RETURN_ON_FALSE(ch32v003, ESP_ERR_NO_MEM, TAG, "Malloc failed");
+
+    ch32v003->base.config.io_count = IO_COUNT;
+    ch32v003->base.config.flags.dir_out_bit_zero = 0;   // 1 = output on this firmware
+    ch32v003->i2c_num = i2c_num;
+    ch32v003->i2c_address = i2c_address;
+    ch32v003->base.read_input_reg = read_input_reg;
+    ch32v003->base.write_output_reg = write_output_reg;
+    ch32v003->base.read_output_reg = read_output_reg;
+    ch32v003->base.write_direction_reg = write_direction_reg;
+    ch32v003->base.read_direction_reg = read_direction_reg;
+    ch32v003->base.del = del;
+    ch32v003->base.reset = reset;
+
+    esp_err_t ret = ESP_OK;
+    /* Reset configuration and register status */
+    ESP_GOTO_ON_ERROR(reset(&ch32v003->base), err, TAG, "Reset failed");
+
+    *handle = &ch32v003->base;
+    return ESP_OK;
+err:
+    free(ch32v003);
+    return ret;
+}
+
+esp_err_t esp_io_expander_waveshare_lcd_4_ch32v003_set_pwm(esp_io_expander_handle_t handle, uint8_t duty)
+{
+    ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "Invalid handle");
+    esp_io_expander_ch32v003_t *ch32v003 = (esp_io_expander_ch32v003_t *)__containerof(handle, esp_io_expander_ch32v003_t, base);
+
+    uint8_t data[] = {PWM_REG_ADDR, duty};
+    ESP_RETURN_ON_ERROR(
+        i2c_master_write_to_device(ch32v003->i2c_num, ch32v003->i2c_address, data, sizeof(data), pdMS_TO_TICKS(I2C_TIMEOUT_MS)),
+        TAG, "Write PWM reg failed");
+    return ESP_OK;
+}
+
+static esp_err_t read_input_reg(esp_io_expander_handle_t handle, uint32_t *value)
+{
+    esp_io_expander_ch32v003_t *ch32v003 = (esp_io_expander_ch32v003_t *)__containerof(handle, esp_io_expander_ch32v003_t, base);
+
+    uint8_t temp = 0;
+    // *INDENT-OFF*
+    ESP_RETURN_ON_ERROR(
+        i2c_master_write_read_device(ch32v003->i2c_num, ch32v003->i2c_address, (uint8_t[]){INPUT_REG_ADDR}, 1, &temp, 1, pdMS_TO_TICKS(I2C_TIMEOUT_MS)),
+        TAG, "Read input reg failed");
+    // *INDENT-ON*
+    *value = temp;
+    return ESP_OK;
+}
+
+static esp_err_t write_output_reg(esp_io_expander_handle_t handle, uint32_t value)
+{
+    esp_io_expander_ch32v003_t *ch32v003 = (esp_io_expander_ch32v003_t *)__containerof(handle, esp_io_expander_ch32v003_t, base);
+    value &= 0xff;
+
+    uint8_t data[] = {OUTPUT_REG_ADDR, value};
+    ESP_RETURN_ON_ERROR(
+        i2c_master_write_to_device(ch32v003->i2c_num, ch32v003->i2c_address, data, sizeof(data), pdMS_TO_TICKS(I2C_TIMEOUT_MS)),
+        TAG, "Write output reg failed");
+    ch32v003->regs.output = value;
+    return ESP_OK;
+}
+
+static esp_err_t read_output_reg(esp_io_expander_handle_t handle, uint32_t *value)
+{
+    esp_io_expander_ch32v003_t *ch32v003 = (esp_io_expander_ch32v003_t *)__containerof(handle, esp_io_expander_ch32v003_t, base);
+
+    *value = ch32v003->regs.output;
+    return ESP_OK;
+}
+
+static esp_err_t write_direction_reg(esp_io_expander_handle_t handle, uint32_t value)
+{
+    esp_io_expander_ch32v003_t *ch32v003 = (esp_io_expander_ch32v003_t *)__containerof(handle, esp_io_expander_ch32v003_t, base);
+    value &= 0xff;
+
+    uint8_t data[] = {DIRECTION_REG_ADDR, value};
+    ESP_RETURN_ON_ERROR(
+        i2c_master_write_to_device(ch32v003->i2c_num, ch32v003->i2c_address, data, sizeof(data), pdMS_TO_TICKS(I2C_TIMEOUT_MS)),
+        TAG, "Write direction reg failed");
+    ch32v003->regs.direction = value;
+    return ESP_OK;
+}
+
+static esp_err_t read_direction_reg(esp_io_expander_handle_t handle, uint32_t *value)
+{
+    esp_io_expander_ch32v003_t *ch32v003 = (esp_io_expander_ch32v003_t *)__containerof(handle, esp_io_expander_ch32v003_t, base);
+
+    *value = ch32v003->regs.direction;
+    return ESP_OK;
+}
+
+static esp_err_t reset(esp_io_expander_t *handle)
+{
+    ESP_RETURN_ON_ERROR(write_direction_reg(handle, DIR_REG_DEFAULT_VAL), TAG, "Write dir reg failed");
+    ESP_RETURN_ON_ERROR(write_output_reg(handle, OUT_REG_DEFAULT_VAL), TAG, "Write output reg failed");
+    return ESP_OK;
+}
+
+static esp_err_t del(esp_io_expander_t *handle)
+{
+    esp_io_expander_ch32v003_t *ch32v003 = (esp_io_expander_ch32v003_t *)__containerof(handle, esp_io_expander_ch32v003_t, base);
+
+    free(ch32v003);
+    return ESP_OK;
+}

--- a/src/port/esp_io_expander_waveshare_lcd_4_ch32v003.h
+++ b/src/port/esp_io_expander_waveshare_lcd_4_ch32v003.h
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief ESP IO expander: Waveshare ESP32-S3-Touch-LCD-4 CH32V003
+ *
+ * @note  The CH32V003 is a microcontroller used as an I2C IO expander. The register map and pin
+ *        assignment implemented here are specific to the firmware shipped on the Waveshare
+ *        ESP32-S3-Touch-LCD-4 (4" square) board. Other boards may use a CH32V003 with different
+ *        firmware, so this driver is intentionally board-scoped.
+ *
+ * @note  Register map (board firmware):
+ *        | Address | Register   | Notes                                    |
+ *        | ------- | ---------- | ---------------------------------------- |
+ *        | 0x00    | INPUT      | Read-only pin input levels               |
+ *        | 0x02    | OUTPUT     | Output latch (readable)                  |
+ *        | 0x03    | DIRECTION  | 1 = output, 0 = input                    |
+ *        | 0x05    | PWM        | Backlight PWM, 0 = max .. 247 = off       |
+ *
+ * @note  Pin map (register bit -> function):
+ *        | Pin (bit) | 1      | 2      | 3       | 4    | 5      | 6      | 7       |
+ *        | --------- | ------ | ------ | ------- | ---- | ------ | ------ | ------- |
+ *        | Function  | TP_RST | TP_INT | LCD_RST | SDCD | SYS_EN | BEE_EN | RTC_INT |
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "driver/i2c.h"
+#include "esp_err.h"
+
+#include "esp_io_expander.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ESP_IO_EXPANDER_WAVESHARE_LCD_4_CH32V003_VER_MAJOR    (1)
+#define ESP_IO_EXPANDER_WAVESHARE_LCD_4_CH32V003_VER_MINOR    (0)
+#define ESP_IO_EXPANDER_WAVESHARE_LCD_4_CH32V003_VER_PATCH    (0)
+
+/**
+ * @brief I2C address of the CH32V003 expander on the Waveshare ESP32-S3-Touch-LCD-4 board
+ */
+#define ESP_IO_EXPANDER_I2C_WAVESHARE_LCD_4_CH32V003_ADDRESS    (0x24)
+
+/**
+ * @brief Create a new Waveshare ESP32-S3-Touch-LCD-4 CH32V003 IO expander driver
+ *
+ * @note The I2C communication should be initialized before use this function
+ *
+ * @param i2c_num: I2C port num
+ * @param i2c_address: I2C address of chip
+ * @param handle: IO expander handle
+ *
+ * @return
+ *      - ESP_OK: Success, otherwise returns ESP_ERR_xxx
+ */
+esp_err_t esp_io_expander_new_i2c_waveshare_lcd_4_ch32v003(i2c_port_t i2c_num, uint32_t i2c_address,
+        esp_io_expander_handle_t *handle);
+
+/**
+ * @brief Set the backlight PWM register
+ *
+ * @note The PWM register is dedicated to backlight control and is not part of the generic GPIO
+ *       model. The duty is inverted by the firmware: 0 = maximum brightness, 247 = off.
+ *
+ * @param handle: IO expander handle
+ * @param duty: Raw PWM register value (0 = max brightness .. 247 = off)
+ *
+ * @return
+ *      - ESP_OK: Success, otherwise returns ESP_ERR_xxx
+ */
+esp_err_t esp_io_expander_waveshare_lcd_4_ch32v003_set_pwm(esp_io_expander_handle_t handle, uint8_t duty);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Added support for the IO-Expander turned CH32V003 microcontroller on the Waveshare S3 Touch LCD 4 (v4) board. 

On this version they've changed the IO expander to a custom micro because they wanted PWM for the backlight. Register addresses also change slightly compared to v3. 

This patch supports the CH32V003 firmware used on this board. The beeper, backlight and necessary relaxation times (the uC is programmed buggy) are supported.  Support for this chip is mandatory to build ESP_Display_Panel support for the LCD 4, for which I'll also submit a PR.